### PR TITLE
Allow fromRemoteWindow to reach into WebViews

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "chai-as-promised": "^6.0.0",
     "cross-env": "^3.0.0",
     "electron-mocha": "^3.1.1",
-    "electron-prebuilt-compile": "1.4.1",
+    "electron-prebuilt-compile": "1.4.14",
     "esdoc": "^0.4.8",
     "esdoc-es7-plugin": "0.0.3",
     "esdoc-plugin-async-to-sync": "^0.5.0",

--- a/src/remote-event-browser.js
+++ b/src/remote-event-browser.js
@@ -1,4 +1,4 @@
-import {BrowserWindow, ipcMain} from 'electron';
+import {BrowserWindow, webContents, ipcMain} from 'electron';
 import {Observable} from 'rxjs/Observable';
 
 import 'rxjs/add/observable/fromEvent';
@@ -19,6 +19,9 @@ function initialize() {
     switch(type) {
     case 'window':
       target = BrowserWindow.fromId(id);
+      break;
+    case 'webcontents':
+      target = webContents.fromId(id);
       break;
     default:
       target = null;

--- a/src/remote-event.js
+++ b/src/remote-event.js
@@ -30,15 +30,23 @@ const d = require('debug')('remote-event');
  *                                Unsubscribing from the Observable will
  *                                remove the event listener.
  */
-export function fromRemoteWindow(browserWindow, event, onWebContents=false) {
+export function fromRemoteWindow(browserWindowOrWebView, event, onWebContents=false) {
   if (isBrowser) {
-    return onWebContents ?
-      Observable.fromEvent(browserWindow.webContents, event, (...args) => args) :
-      Observable.fromEvent(browserWindow, event, (...args) => args);
+    if (onWebContents) {
+      let wc = ('webContents' in browserWindowOrWebView ? browserWindowOrWebView.webContents : browserWindowOrWebView.getWebContents());
+      return Observable.fromEvent(wc, event, (...args) => args);
+    } else {
+      Observable.fromEvent(browserWindowOrWebView, event, (...args) => args);
+    }
   }
 
-  let type = 'window';
-  let id = browserWindow.id;
+  let type = onWebContents ? 'webcontents' : 'window';
+  let id;
+  if (onWebContents) {
+    id = ('webContents' in browserWindowOrWebView ? browserWindowOrWebView.webContents : browserWindowOrWebView.getWebContents()).id;
+  } else {
+    id = browserWindowOrWebView.id;
+  }
 
   const key = `electron-remote-event-${type}-${id}-${event}-${remote.getCurrentWebContents().id}`;
 

--- a/src/remote-event.js
+++ b/src/remote-event.js
@@ -40,6 +40,10 @@ export function fromRemoteWindow(browserWindowOrWebView, event, onWebContents=fa
     }
   }
 
+  if (Object.getPrototypeOf(browserWindowOrWebView).constructor.name === 'webview' && !onWebContents) {
+    throw new Error("WebViews can only be used with onWebContents=true");
+  }
+
   let type = onWebContents ? 'webcontents' : 'window';
   let id;
   if (onWebContents) {


### PR DESCRIPTION
This PR allows fromRemoteWindow to work with WebView tags, if we're trying to capture a WebContents