### PR TITLE
Test requireTaskPool

### DIFF
--- a/src/custom-operators.js
+++ b/src/custom-operators.js
@@ -3,6 +3,7 @@ import {Scheduler} from 'rxjs/Scheduler';
 
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/switch';
+import 'rxjs/add/observable/timer';
 
 const newCoolOperators = {
   guaranteedThrottle: function (time, scheduler=Scheduler.timeout) {

--- a/test/renderer-require.js
+++ b/test/renderer-require.js
@@ -1,4 +1,17 @@
-import {rendererRequireDirect} from '../src/renderer-require';
+import {rendererRequireDirect, requireTaskPool} from '../src/renderer-require';
+
+describe('the requireTaskPool method', function() {
+  this.timeout(10*1000);
+
+  it('can make a bunch of requests at once', async function() {
+    const { getJSON } = requireTaskPool(require.resolve('../src/remote-ajax', 10));
+
+    for (let i = 0; i < 20; i++) {
+      const result = await getJSON('https://httpbin.org/get');
+      expect(result.url).to.equal('https://httpbin.org/get');
+    }
+  });
+});
 
 describe('the rendererRequireDirect method', function() {
   this.timeout(10*1000);

--- a/test/renderer-require.js
+++ b/test/renderer-require.js
@@ -4,12 +4,19 @@ describe('the requireTaskPool method', function() {
   this.timeout(10*1000);
 
   it('can make a bunch of requests at once', async function() {
-    const { getJSON } = requireTaskPool(require.resolve('../src/remote-ajax', 10));
+    const { getJSON } = requireTaskPool(
+      require.resolve('../src/remote-ajax'),
+      10,     // Allow 10 windows open at a time
+      200);   // Close idle windows after 500ms
 
-    for (let i = 0; i < 20; i++) {
-      const result = await getJSON('https://httpbin.org/get');
-      expect(result.url).to.equal('https://httpbin.org/get');
-    }
+    const emptyArray = Array.apply(null, Array(20)).map(() => 0);
+    const result = await Promise.all(emptyArray.map(() => getJSON('https://httpbin.org/get')));
+
+    expect(result.length).to.equal(20);
+    result.forEach(({ url }) => expect(url).to.equal('https://httpbin.org/get'));
+
+    // Give the windows some time to close.
+    await new Promise((res) => setTimeout(res, 400));
   });
 });
 


### PR DESCRIPTION
This just adds a test for `requireTaskPool`. It also checks if a window is already inaccessible before calling `close` on it (which throws) and instead calls `destroy`.