### PR TITLE
Letting users pick their favourite modules loading method

### DIFF
--- a/src/renderer-require.js
+++ b/src/renderer-require.js
@@ -40,7 +40,6 @@ const BrowserWindow = process.type === 'renderer' ?
  */
 export async function rendererRequireDirect(modulePath) {
   let bw = new BrowserWindow({width: 500, height: 500, show: false});
-  let fullPath = require.resolve(modulePath);
 
   let ready = Observable.merge(
     fromRemoteWindow(bw, 'did-finish-load', true),
@@ -54,7 +53,7 @@ export async function rendererRequireDirect(modulePath) {
   */
 
   let preloadFile = path.join(__dirname, 'renderer-require-preload.html');
-  bw.loadURL(`file:///${preloadFile}?module=${encodeURIComponent(fullPath)}`);
+  bw.loadURL(`file:///${preloadFile}?module=${encodeURIComponent(modulePath)}`);
   await ready;
 
   let fail = await executeJavaScriptMethod(bw, 'window.moduleLoadFailure');


### PR DESCRIPTION
Removing `require.resolve` from `rendererRequireDirect` allows users to load modules in different fashions: 

- webpack-packed modules (ie: `ElectronRemote.requireTaskPool(require.resolve('electron-remote/remote-ajax'));`)
- absolute/relative files (`ElectronRemote.requireTaskPool('../../../dist/electron/workers/uploadWorker');`)
- possibly other ways that don't come into my mind right now :)

See issue #19 