### PR TITLE
Filter “Error: OK”

### DIFF
--- a/src/renderer-require.js
+++ b/src/renderer-require.js
@@ -45,6 +45,7 @@ export async function rendererRequireDirect(modulePath) {
   let ready = Observable.merge(
     fromRemoteWindow(bw, 'did-finish-load', true),
     fromRemoteWindow(bw, 'did-fail-load', true)
+      .filter(([, errCode]) => errCode !== 0)
       .mergeMap(([, , errMsg]) => Observable.throw(new Error(errMsg)))
     ).take(1).toPromise();
 


### PR DESCRIPTION
Chrome is somehow capable of emitting an "OK" error (code 0) on `did-fail-load`. Turns out, that's not actually an error. We've been handling that non-error in our app's code for a while now with good results.

This PR ensures that non-errors are filtered.