### PR TITLE
Add ‘createProxyForMainProcessModule’

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ electron-remote provides an alternative to Electron's `remote` module based arou
 
 ## The Quickest of Quick Starts
 
+###### Calling main process modules from a renderer
+
+```js
+import { createProxyForMainProcessModule } from 'electron-remote';
+
+// app is now a proxy for the app module in the main process
+const app = createProxyForMainProcessModule('app');
+
+// The difference is all methods return a Promise instead of blocking
+const memoryInfo = await app.getAppMemoryInfo();
+```
+
 ###### Calling code in other windows
 
 ```js
@@ -33,7 +45,7 @@ let result = await myCoolModule.calculateDigitsOfPi(100000);
 
 ## But I like Remote!
 
-Remote is super convenient! But it also has some downsides - its main downside is that its action is **synchronous**. This means that both the main and window processes will _wait_ for a method to finish running. Even for quick methods, calling it too often can introduce scroll jank and generally cause performance problems. 
+Remote is super convenient! But it also has some downsides - its main downside is that its action is **synchronous**. This means that both the main and window processes will _wait_ for a method to finish running. Even for quick methods, calling it too often can introduce scroll jank and generally cause performance problems.
 
 electron-remote is a version of remote that, while less ergonomic, guarantees that it won't block the calling thread.
 
@@ -78,9 +90,12 @@ window.addNumbers = (a,b) => a + b;
 let myWindowProxy = createProxyForRemote(myWindow);
 myWindowProxy.addNumbers(5, 5)
   .then((x) => console.log(x));
-  
+
 >>> 10
 ```
+
+#### Using createProxyForMainProcessModule
+This is meant to be a drop-in replacement for places you would have used `remote` in a renderer process. It's almost identical to `createProxyForRemote`, but instead of `eval`ing JavaScript it can only call methods on main process modules. It still has all the same benefits: asynchronous IPC instead of an `ipc.sendSync`.
 
 ## Here Be Dragons
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "debug": "^2.5.1",
     "hashids": "^1.1.1",
+    "lodash.get": "^4.4.2",
     "pify": "^2.3.0",
     "rxjs": "^5.0.0-beta.12",
     "xmlhttprequest": "^1.8.0"

--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,14 @@ import * as remoteEvent from './remote-event';
 
 const executeJsFuncExports = [
   'createProxyForRemote',
-  'getSenderIdentifier', 
+  'createProxyForMainProcessModule',
+  'getSenderIdentifier',
   'executeJavaScriptMethodObservable',
   'executeJavaScriptMethod',
   'initializeEvalHandler',
-  'remoteEvalObservable', 
+  'remoteEvalObservable',
   'remoteEval',
-  'setParentInformation', 
+  'setParentInformation',
   'RecursiveProxyHandler'
 ];
 


### PR DESCRIPTION
This PR adds a new `createProxyForMainProcessModule` method that has similar ergonomics to `createProxyForRemote`, but makes it easier to call main process modules from a renderer.

The main difference is instead of `eval`ing code, when the main process receives a request, it does:
``` js
const theModule = electron[receive.moduleName];
const methodToCall = get(theModule, receive.path);
receive.result = methodToCall.apply(theModule, receive.args);
```

This came about because I just want a Promisified version of `remote`, and `createProxyForRemote` doesn't get me quite there. E.g., if I do

``` js
const mainProcess = createProxyForRemote();
```

I can't call out to Electron modules in the main process without _first_ defining some method on the global scope.