### PR TITLE
Don't save the response if HTTP response is not OK

### DIFF
--- a/src/remote-ajax.js
+++ b/src/remote-ajax.js
@@ -65,6 +65,10 @@ module.exports.downloadFileOrUrl = async function(pathOrUrl, target) {
     redirect: 'follow'
   });
 
+  if (!response.ok) {
+    throw new Error(`HTTP request returned error: ${response.status}: ${response.statusText}`);
+  }
+
   let fd = await fs.open(target, 'w');
   let length = 0;
   try {
@@ -87,10 +91,6 @@ module.exports.downloadFileOrUrl = async function(pathOrUrl, target) {
     }
   } finally {
     await fs.close(fd);
-  }
-
-  if (!response.ok) {
-    throw new Error(`HTTP request returned error: ${response.status}: ${response.statusText}`);
   }
 
   return length;


### PR DESCRIPTION
Issue: If the HTTP response is not 200, file is downloaded with the HTTP response text in it. 

Fix: Stopping the file write if the response is not OK.